### PR TITLE
Fix osx-arm64 cross-compile and SIGABRT memory errors.

### DIFF
--- a/recipe/install_libapr.sh
+++ b/recipe/install_libapr.sh
@@ -12,8 +12,12 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" && $target_platform == "osx-arm64"
   export ac_cv_func_setpgrp_void=yes
   export apr_cv_process_shared_works=yes
   export apr_cv_mutex_robust_shared=no
+  export apr_cv_mutex_recursive=yes
   export apr_cv_tcp_nodelay_with_cork=no
   export ac_cv_sizeof_struct_iovec=16
+  export ap_cv_atomic_builtins=yes
+  export apr_cv_gai_addrconfig=yes
+  export ac_cv_sizeof_pid_t=4
 fi
 
 autoreconf -vfi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
       - patches/osx-libapr-darwin20-hints.patch
       # backport of commit 866e1df from upstream
       - patches/cross-compile-apr-866e1df.patch
+      - patches/cross-compile-osx-arm64-strerror.patch  # [osx and build_platform != target_platform]
   - url: {{ mirror }}/apr/apr-util-{{ apu_ver }}.tar.gz
     folder: apr-util
     sha256: b65e40713da57d004123b6319828be7f1273fbc6490e145874ee1177e112c459
@@ -24,7 +25,7 @@ source:
   - path: cmake/  # [win]
 
 build:
-  number: 3
+  number: 4
   ignore_run_exports:                                           # [win]
     - expat                                                     # [win]
   skip: true  # [win and vc<14]

--- a/recipe/patches/cross-compile-osx-arm64-strerror.patch
+++ b/recipe/patches/cross-compile-osx-arm64-strerror.patch
@@ -1,0 +1,11 @@
+--- build/apr_common.m4.orig	2021-01-27 08:53:48.000000000 -0800
++++ build/apr_common.m4	2021-01-27 08:54:08.000000000 -0800
+@@ -543,7 +543,7 @@
+ }], [
+     ac_cv_strerror_r_rc_int=yes ], [
+     ac_cv_strerror_r_rc_int=no ], [
+-    ac_cv_strerror_r_rc_int=no ] )
++    ac_cv_strerror_r_rc_int=yes ] )
+ if test "x$ac_cv_strerror_r_rc_int" = xyes; then
+   AC_DEFINE(STRERROR_R_RC_INT, 1, [Define if strerror returns int])
+   msg="int"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Apologies, I had not correctly configured all the config variables when doing the original porting, and this would lead to SIGABRT when using `log4cxx` which is based on `apr`.  I have confirmed that these fixes (a) yield an identical output from `configure` to the native build, and (b) work properly with `log4cxx` (in simple testing, at least).

<!--
Please add any other relevant info below:
-->
